### PR TITLE
Change clinical attribute api

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.java
@@ -18,9 +18,11 @@ public interface ClinicalFieldMapper {
 	List<DBClinicalField> getSampleClinicalFieldsByStudy(@Param("study_id") String study_id);
 	List<DBClinicalField> getPatientClinicalFieldsByStudy(@Param("study_id") String study_id);
 	
-	List<DBClinicalField> getSampleClinicalFieldsBySample(@Param("study_id") String study_id, @Param("sample_ids") List<String> sample_ids);
+    List<DBClinicalField> getSampleClinicalFieldsBySample(@Param("study_id") String study_id, @Param("sample_ids") List<String> sample_ids);
+    List<DBClinicalField> getSampleClinicalFieldsBySampleInternalIds(@Param("study_id") String study_id, @Param("sample_ids") List<Integer> sample_ids);
 	List<DBClinicalField> getPatientClinicalFieldsByPatient(@Param("study_id") String study_id, @Param("patient_ids") List<String> patient_ids);
-	
-	List<DBClinicalField> getAllSampleClinicalFields();
+    List<DBClinicalField> getPatientClinicalFieldsByPatientInternalIds(@Param("study_id") String study_id, @Param("patient_ids") List<Integer> patient_ids);
+
+    List<DBClinicalField> getAllSampleClinicalFields();
 	List<DBClinicalField> getAllPatientClinicalFields();
 }

--- a/business/src/main/java/org/mskcc/cbio/portal/persistence/PatientMapper.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/persistence/PatientMapper.java
@@ -18,4 +18,5 @@ public interface PatientMapper {
 	List<DBPatient> getPatientsByPatient(@Param("study_id") String study_id, @Param("patient_ids") List<String> patient_ids);
 	List<DBPatient> getPatientsBySample(@Param("study_id") String study_id, @Param("patient_ids") List<String> sample_ids);
 	List<DBPatient> getPatientsByStudy(@Param("study_id") String study_id);
+    List<Integer> getPatientInternalIdsByStudy(@Param("study_id") String study_id);
 }

--- a/business/src/main/java/org/mskcc/cbio/portal/persistence/SampleMapper.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/persistence/SampleMapper.java
@@ -3,6 +3,7 @@ package org.mskcc.cbio.portal.persistence;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.plugin.Interceptor;
 import org.mskcc.cbio.portal.model.DBSample;
 
 /*
@@ -17,6 +18,7 @@ import org.mskcc.cbio.portal.model.DBSample;
 public interface SampleMapper {
 	List<DBSample> getSamplesBySample(@Param("study_id") String study_id, @Param("sample_ids") List<String> sample_ids);
 	List<DBSample> getSamplesByStudy(@Param("study_id") String study_id);
+    List<Integer> getSampleInternalIdsByStudy(@Param("study_id") String study_id);
 	List<DBSample> getSamplesByInternalId(@Param("sample_ids") List<String> sample_ids);
-        List<DBSample> getSamplesByPatient(@Param("study_id") String study_id, @Param("patient_ids") List<String> patient_ids);
+    List<DBSample> getSamplesByPatient(@Param("study_id") String study_id, @Param("patient_ids") List<String> patient_ids);
 }

--- a/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
@@ -106,6 +106,11 @@ public class ApiService {
 	public List<DBClinicalField> getSampleClinicalAttributes(String study_id, List<String> sample_ids) {
 		return clinicalFieldMapper.getSampleClinicalFieldsBySample(study_id, sample_ids);
 	}
+    
+    @Transactional
+    public List<DBClinicalField> getSampleClinicalAttributesByInternalIds(String study_id, List<Integer> sample_ids) {
+        return clinicalFieldMapper.getSampleClinicalFieldsBySampleInternalIds(study_id, sample_ids);
+    }
 
 	@Transactional
 	public List<DBClinicalField> getPatientClinicalAttributes() {
@@ -121,6 +126,11 @@ public class ApiService {
 	public List<DBClinicalField> getPatientClinicalAttributes(String study_id, List<String> patient_ids) {
 		return clinicalFieldMapper.getPatientClinicalFieldsByPatient(study_id, patient_ids);
 	}
+
+    @Transactional
+    public List<DBClinicalField> getPatientClinicalAttributesByInternalIds(String study_id, List<Integer> patient_ids) {
+        return clinicalFieldMapper.getPatientClinicalFieldsByPatientInternalIds(study_id, patient_ids);
+    }
 
 	@Transactional
 	public List<DBGene> getGenes() {
@@ -179,6 +189,11 @@ public class ApiService {
 		return patientMapper.getPatientsByStudy(study_id);
 	}
 
+    @Transactional
+    public List<Integer> getPatientInternalIdsByStudy(String study_id) {
+        return patientMapper.getPatientInternalIdsByStudy(study_id);
+    }
+    
 	@Transactional
 	public List<DBPatient> getPatientsByPatient(String study_id, List<String> patient_ids) {
 		return patientMapper.getPatientsByPatient(study_id, patient_ids);
@@ -295,6 +310,11 @@ public class ApiService {
 	public List<DBSample> getSamples(String study_id) {
 		return sampleMapper.getSamplesByStudy(study_id);
 	}
+    
+    @Transactional
+    public List<Integer> getSampleInternalIds(String study_id) {
+        return sampleMapper.getSampleInternalIdsByStudy(study_id);
+    }
 
 	@Transactional
 	public List<DBSample> getSamplesBySample(String study_id, List<String> sample_ids) {

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.xml
@@ -36,6 +36,15 @@
     where cancer_study.CANCER_STUDY_IDENTIFIER=#{study_id}
     and sample.STABLE_ID in <foreach item="item" collection="sample_ids" open="(" separator="," close=")">#{item}</foreach>
 </select>
+<select id="getSampleClinicalFieldsBySampleInternalIds" resultMap="ClinicalFieldResult">
+    select distinct clinical_attribute.ATTR_ID,clinical_attribute.DISPLAY_NAME,clinical_attribute.DESCRIPTION,clinical_attribute.DATATYPE,clinical_attribute.PATIENT_ATTRIBUTE,clinical_attribute.PRIORITY from clinical_attribute
+    inner join clinical_sample on clinical_sample.ATTR_ID = clinical_attribute.ATTR_ID
+    inner join sample on clinical_sample.INTERNAL_ID = sample.INTERNAL_ID
+    inner join patient on sample.PATIENT_ID = patient.INTERNAL_ID
+    inner join cancer_study on patient.CANCER_STUDY_ID=cancer_study.CANCER_STUDY_ID
+    where cancer_study.CANCER_STUDY_IDENTIFIER=#{study_id}
+    and sample.INTERNAL_ID in <foreach item="item" collection="sample_ids" open="(" separator="," close=")">#{item}</foreach>
+</select>
 <select id="getPatientClinicalFieldsByPatient" resultMap="ClinicalFieldResult">
     select distinct clinical_attribute.ATTR_ID,clinical_attribute.DISPLAY_NAME,clinical_attribute.DESCRIPTION,clinical_attribute.DATATYPE,clinical_attribute.PATIENT_ATTRIBUTE,clinical_attribute.PRIORITY from clinical_attribute
                 inner join clinical_patient on clinical_patient.ATTR_ID = clinical_attribute.ATTR_ID
@@ -43,6 +52,14 @@
                 inner join cancer_study on patient.CANCER_STUDY_ID=cancer_study.CANCER_STUDY_ID
     where cancer_study.CANCER_STUDY_IDENTIFIER=#{study_id}
     and patient.STABLE_ID in <foreach item="item" collection="patient_ids" open="(" separator="," close=")">#{item}</foreach>
+</select>
+<select id="getPatientClinicalFieldsByPatientInternalIds" resultMap="ClinicalFieldResult">
+    select distinct clinical_attribute.ATTR_ID,clinical_attribute.DISPLAY_NAME,clinical_attribute.DESCRIPTION,clinical_attribute.DATATYPE,clinical_attribute.PATIENT_ATTRIBUTE,clinical_attribute.PRIORITY from clinical_attribute
+    inner join clinical_patient on clinical_patient.ATTR_ID = clinical_attribute.ATTR_ID
+    inner join patient on patient.INTERNAL_ID = clinical_patient.INTERNAL_ID
+    inner join cancer_study on patient.CANCER_STUDY_ID=cancer_study.CANCER_STUDY_ID
+    where cancer_study.CANCER_STUDY_IDENTIFIER=#{study_id}
+    and patient.INTERNAL_ID in <foreach item="item" collection="patient_ids" open="(" separator="," close=")">#{item}</foreach>
 </select>
 
 <select id="getAllSampleClinicalFields" resultMap="ClinicalFieldResult">

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/PatientMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/PatientMapper.xml
@@ -29,4 +29,11 @@
     from patient inner join cancer_study on patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
     where cancer_study.CANCER_STUDY_IDENTIFIER = #{study_id}
 </select>
+
+<select id="getPatientInternalIdsByStudy" resultType="Integer">
+    select
+    patient.INTERNAL_ID
+    from patient inner join cancer_study on patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+    where cancer_study.CANCER_STUDY_IDENTIFIER = #{study_id}
+</select>
 </mapper>

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/SampleMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/SampleMapper.xml
@@ -24,6 +24,13 @@
                 inner join cancer_study on patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
     where cancer_study.CANCER_STUDY_IDENTIFIER = #{study_id}
 </select>
+<select id="getSampleInternalIdsByStudy" resultType="Integer">
+    select
+    sample.INTERNAL_ID
+    from sample inner join patient on sample.PATIENT_ID = patient.INTERNAL_ID
+    inner join cancer_study on patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+    where cancer_study.CANCER_STUDY_IDENTIFIER = #{study_id}
+</select>
 <select id="getSamplesByInternalId" resultType="DBSample">
     select
         sample.STABLE_ID as id,

--- a/web/src/main/java/org/mskcc/cbio/portal/web/api/ApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/api/ApiController.java
@@ -117,7 +117,7 @@ public class ApiController {
         } else if (study_id != null && sample_ids != null) {
             return service.getSampleClinicalAttributes(study_id, sample_ids);
         } else if (sample_ids == null) {
-            return service.getSampleClinicalAttributes(study_id);
+            return service.getSampleClinicalAttributesByInternalIds(study_id, service.getSampleInternalIds(study_id));
         } else {
             return new ArrayList<>();
         }
@@ -140,7 +140,7 @@ public class ApiController {
         } else if (study_id != null && patient_ids != null) {
             return service.getPatientClinicalAttributes(study_id, patient_ids);
         } else if (patient_ids == null) {
-            return service.getPatientClinicalAttributes(study_id);
+            return service.getPatientClinicalAttributesByInternalIds(study_id, service.getPatientInternalIdsByStudy(study_id));
         } else {
             return new ArrayList<>();
         }


### PR DESCRIPTION
Querying study clinical attributes without specify patient/sample
should always get list of patient/sample internal Ids before the query.
